### PR TITLE
Return the output of a command when printed

### DIFF
--- a/src/Common/ExecTrait.php
+++ b/src/Common/ExecTrait.php
@@ -60,6 +60,11 @@ trait ExecTrait
      * @var string
      */
     protected $workingDirectory;
+    
+    /**
+     * @var string
+     */
+    protected $output = '';
 
     /**
      * @return string
@@ -286,6 +291,7 @@ trait ExecTrait
 
         if (!$output_callback) {
             $output_callback = function ($type, $buffer) {
+                $this->output .=  $buffer;
                 $progressWasVisible = $this->hideTaskProgress();
                 $this->writeMessage($buffer);
                 $this->showTaskProgress($progressWasVisible);
@@ -332,7 +338,7 @@ trait ExecTrait
             $this->stopTimer();
             return new ResultData(
                 $this->process->getExitCode(),
-                $this->process->getOutput(),
+                $this->output,
                 $this->getResultData()
             );
         }


### PR DESCRIPTION
Even if the command output has been displayed, return it as part of the Result object anyway

### Overview
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
When printing output of a command, before this change the output couldn't be accessed. This change allows the output to be saved and returned as part of the Result object so it can be scripted

### Description
Improves how the callback for handling Process output is using the buffer and keep a copy of it so it can be returned as part of the result.